### PR TITLE
Correct timings for LD (C),A and LD A,(C) and STOP

### DIFF
--- a/opcodes.json
+++ b/opcodes.json
@@ -246,7 +246,7 @@
     },
     "0x10": {
       "mnemonic": "STOP",
-      "length": 2,
+      "length": 1,
       "cycles": [
         4
       ],
@@ -3479,7 +3479,7 @@
     },
     "0xe2": {
       "mnemonic": "LD",
-      "length": 2,
+      "length": 1,
       "cycles": [
         8
       ],
@@ -3648,7 +3648,7 @@
     },
     "0xf2": {
       "mnemonic": "LD",
-      "length": 2,
+      "length": 1,
       "cycles": [
         8
       ],


### PR DESCRIPTION
According to the StackExchange answer given at https://stackoverflow.com/a/41422692,
the instructions are 1 byte long, not 2. It seems like there was an error in the original documentation.

This should hopefully help future Gameboy emulator developers that make use of this wonderful gem.